### PR TITLE
Add user-facing version display (--version / -v) and show version in …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overlays"
-version = "1.6.0"
+version = "1.6.1"
 description = "A lightweight Windows overlay manager and client library for creating click through overlay windows."
 readme = "README.md"
 authors = [

--- a/src/overlays/main.py
+++ b/src/overlays/main.py
@@ -4,7 +4,7 @@ from importlib.metadata import version
 
 
 def cross_platform_helper():
-    if "--version" in sys.argv or "-v" in sys.argv:
+    if "--version" in sys.argv:
         print(f"overlays {version('overlays')}")
         return
 

--- a/src/overlays/main.py
+++ b/src/overlays/main.py
@@ -1,7 +1,13 @@
 import platform
+import sys
+from importlib.metadata import version
 
 
 def cross_platform_helper():
+    if "--version" in sys.argv or "-v" in sys.argv:
+        print(f"overlays {version('overlays')}")
+        return
+
     if platform.system() != "Windows":
         print("❌ Error: This application is designed to run on Windows only.")
         exit(1)

--- a/src/overlays/manager.py
+++ b/src/overlays/manager.py
@@ -541,8 +541,10 @@ def signal_handler(sig: int, frame: FrameType | None) -> None:
 
 
 def main() -> None:
-    print("🔧 OverlayManager - Windows Overlay Application")
-    print("================================================")
+    from importlib.metadata import version
+
+    print(f"🔧 OverlayManager v{version('overlays')} - Windows Overlay Application")
+    print("=========================================================")
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
     print("✅ Signal handlers configured")

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "overlays"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
…startup banner

Reads the version from package metadata so it stays in sync with pyproject.toml automatically. Bump version to 1.6.1.